### PR TITLE
Do not leak expected signature from exception

### DIFF
--- a/JWT.Tests/JWTFixture.cs
+++ b/JWT.Tests/JWTFixture.cs
@@ -32,7 +32,7 @@ namespace JWT.Tests
             }
             catch (SignatureVerificationException ex)
             {
-                Assert.AreEqual("Invalid signature. Expected 8Qh5lJ5gSaQylkSdaCIDBoOqKzhoJ0Nutkkap8RgB1Y= got 8Qh5lJ5gSaQylkSdaCIDBoOqKzhoJ0Nutkkap8RgBOo=", ex.Message);
+                Assert.AreEqual("Invalid signature.", ex.Message);
                 return;
             }
 

--- a/JWT/JWT.cs
+++ b/JWT/JWT.cs
@@ -102,7 +102,7 @@ namespace JWT
 
                 if (decodedCrypto != decodedSignature)
                 {
-                    throw new SignatureVerificationException(string.Format("Invalid signature. Expected {0} got {1}", decodedCrypto, decodedSignature));
+                    throw new SignatureVerificationException("Invalid signature.");
                 }
             }
 


### PR DESCRIPTION
Security fix: When the signature does not match do no leak the expected signature.